### PR TITLE
Remove duplicate tasks section from site.yml

### DIFF
--- a/site.yml
+++ b/site.yml
@@ -5,6 +5,5 @@
    - name: group hosts by distribution
      action: group_by key={{ansible_distribution}}
 
-  tasks:
-    - name: site | hello world
-      shell: echo "Hi! AWX is working"
+   - name: site | hello world
+     shell: echo "Hi! AWX is working"


### PR DESCRIPTION
Noticed that running `site.yml` in our tests resulted in the error:

`[WARNING]: While constructing a mapping from
/var/lib/awx/projects/_7__project_2/site.yml, line 3, column 3, found a
duplicate dict key (tasks).  Using last defined value only.`

![screenshot 2016-07-14 17 17 49](https://cloud.githubusercontent.com/assets/4440360/16856203/e710a98c-49e6-11e6-94ab-ca4adbce3ce6.png)

Updated site.yml, removing duplicate `tasks` section.