### PR TITLE
add debug task for list of vars

### DIFF
--- a/debug_var_list.yml
+++ b/debug_var_list.yml
@@ -1,0 +1,12 @@
+---
+
+- hosts: all
+  gather_facts: false
+  vars:
+    first: 'one'
+    second: 'fine'
+    third: 'day'
+    results: ['{{ first  }}', '{{ second  }}', '{{ third  }}']
+  tasks:
+    - debug:
+        var: results


### PR DESCRIPTION
Adds a playbook that uses the debug module and a list to exercise a callback plugin issue.