### PR TITLE
Update use_facts.yml to source additional variables

### DIFF
--- a/use_facts.yml
+++ b/use_facts.yml
@@ -5,7 +5,57 @@
   tasks:
     - debug:
         msg: '{{ansible_distribution}}'
+      tags:
+        - ansible_facts
     - debug:
         msg: '{{ansible_machine}}'
+      tags:
+        - ansible_facts
     - debug:
         msg: '{{ansible_system}}'
+      tags:
+        - ansible_facts
+    - debug:
+        msg: '{{ansible_date_time.time}}'
+      tags:
+        - ansible_facts
+    - debug:
+        msg: '{{string}}'
+      tags:
+        - custom_facts
+    - debug:
+        msg: '{{unicode_string}}'
+      tags:
+        - custom_facts
+    - debug:
+        msg: '{{int}}'
+      tags:
+        - custom_facts
+    - debug:
+        msg: '{{float}}'
+      tags:
+        - custom_facts
+    - debug:
+        msg: '{{bool}}'
+      tags:
+        - custom_facts
+    - debug:
+        msg: '{{null}}'
+      tags:
+        - custom_facts
+    - debug:
+        msg: '{{list}}'
+      tags:
+        - custom_facts
+    - debug:
+        msg: '{{obj}}'
+      tags:
+        - custom_facts
+    - debug:
+        msg: '{{empty_list}}'
+      tags:
+        - custom_facts
+    - debug:
+        msg: '{{empty_obj}}'
+      tags:
+        - custom_facts


### PR DESCRIPTION
### Description

Currently `use_facts.yml` only supports sourcing `ansible_facts`. The following allows us to source an additional (changing) `ansible_fact` and our custom facts.