### PR TITLE
allow set_stats playbook to take extra_vars

### DIFF
--- a/test_set_stats.yml
+++ b/test_set_stats.yml
@@ -1,31 +1,33 @@
 ---
 - hosts: localhost
-  tasks:
-  - set_stats:
-      data:
+  vars:
+    set_stats_data:
+      string: 'abc'
+      integer: 123
+      float: 1.0
+      unicode: '竳䙭韽'
+      boolean: true
+      none: null
+      list:
+        - 'abc'
+        - 123
+        - 1.0
+        - '竳䙭韽'
+        - true
+        - null
+        - []
+        - {}
+      object:
         string: 'abc'
         integer: 123
         float: 1.0
         unicode: '竳䙭韽'
         boolean: true
-        none: null
-        list:
-          - 'abc'
-          - 123
-          - 1.0
-          - '竳䙭韽'
-          - true
-          - null
-          - []
-          - {}
-        object:
-          string: 'abc'
-          integer: 123
-          float: 1.0
-          unicode: '竳䙭韽'
-          boolean: true
-          none: null            
-          list: []
-          object: {}
-        empty_list: []
-        empty_object: {} 
+        none: null            
+        list: []
+        object: {}
+      empty_list: []
+      empty_object: {} 
+  tasks:
+  - set_stats:
+      data: "{{ set_stats_data }}"


### PR DESCRIPTION
* Make the set_stats playbook more generic by exposing the set of
set_stats data via a variable. This will allow a user to control the
data that gets passed to set_stats via ansible extra vars (-e) from the
outside (without playbook modification). At the same time, the old
behavior is maintained with default set_stats data.